### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A Node.js server that uses FFmpeg to manipulate video files. This server provide
 - Resize videos to different resolutions (360p, 480p, 720p, 1080p)
 - Extract audio from videos in various formats (MP3, AAC, WAV, OGG)
 
+<a href="https://glama.ai/mcp/servers/@bitscorp-mcp/mcp-ffmpeg">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bitscorp-mcp/mcp-ffmpeg/badge" alt="FFmpeg Video Processor MCP server" />
+</a>
+
 ## Prerequisites
 
 Before running this application, you need to have the following installed:


### PR DESCRIPTION
This PR adds a badge for the [MCP FFmpeg Video Processor](https://glama.ai/mcp/servers/@bitscorp-mcp/mcp-ffmpeg) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bitscorp-mcp/mcp-ffmpeg">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bitscorp-mcp/mcp-ffmpeg/badge" alt="FFmpeg Video Processor MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.